### PR TITLE
Changed optional tool fields to support null (OpenAI/Lanchain compatible)

### DIFF
--- a/src/tools/copyBoard.ts
+++ b/src/tools/copyBoard.ts
@@ -8,10 +8,10 @@ const copyBoardTool: ToolSchema = {
   description: "Create a copy of an existing Miro board with optional new settings",
   args: {
     copyFrom: z.string().describe("Unique identifier (ID) of the board that you want to copy"),
-    name: z.string().optional().describe("Name for the new copied board"),
-    description: z.string().optional().describe("Description for the new copied board"),
-    sharingPolicy: z.enum(['private', 'view', 'comment', 'edit']).optional().describe("Sharing policy for the new copied board"),
-    teamId: z.string().optional().describe("Team ID to assign the new copied board to")
+    name: z.string().optional().nullish().describe("Name for the new copied board"),
+    description: z.string().optional().nullish().describe("Description for the new copied board"),
+    sharingPolicy: z.enum(['private', 'view', 'comment', 'edit']).optional().nullish().describe("Sharing policy for the new copied board"),
+    teamId: z.string().optional().nullish().describe("Team ID to assign the new copied board to")
   },
   fn: async ({ copyFrom, name, description, sharingPolicy, teamId }) => {
     try {

--- a/src/tools/createAppCardItem.ts
+++ b/src/tools/createAppCardItem.ts
@@ -13,23 +13,23 @@ const createAppCardItemTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board where the app card will be created"),
     data: z.object({
       title: z.string().describe("Title of the app card"),
-      description: z.string().optional().describe("Description of the app card"),
-      status: z.string().optional().describe("Status text of the app card"),
+      description: z.string().optional().nullish().describe("Description of the app card"),
+      status: z.string().optional().nullish().describe("Status text of the app card"),
       fields: z.array(z.object({
         value: z.string().describe("Value of the field"),
-        iconShape: z.string().optional().describe("Shape of the icon"),
-        fillColor: z.string().optional().describe("Fill color of the field"),
-        textColor: z.string().optional().describe("Color of the text"),
-      })).optional().describe("Custom fields to display on the app card")
+        iconShape: z.string().optional().nullish().describe("Shape of the icon"),
+        fillColor: z.string().optional().nullish().describe("Fill color of the field"),
+        textColor: z.string().optional().nullish().describe("Color of the text"),
+      })).optional().nullish().describe("Custom fields to display on the app card")
     }).describe("The content and configuration of the app card"),
     position: z.object({
       x: z.number().describe("X coordinate of the app card"),
       y: z.number().describe("Y coordinate of the app card")
     }).describe("Position of the app card on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Width of the app card"),
-      height: z.number().optional().describe("Height of the app card")
-    }).optional().describe("Dimensions of the app card")
+      width: z.number().optional().nullish().describe("Width of the app card"),
+      height: z.number().optional().nullish().describe("Height of the app card")
+    }).optional().nullish().describe("Dimensions of the app card")
   },
   fn: async ({boardId, data, position, geometry}) => {
     try {

--- a/src/tools/createBoard.ts
+++ b/src/tools/createBoard.ts
@@ -8,9 +8,9 @@ const createBoardTool: ToolSchema = {
   description: "Create a new Miro board with specified name and sharing policies",
   args: {
     name: z.string().describe("Name of the board to create"),
-    description: z.string().optional().describe("Description of the board"),
-    sharingPolicy: z.enum(['private', 'view', 'comment', 'edit']).optional().describe("Sharing policy for the board"),
-    teamId: z.string().optional().describe("Team ID to assign the board to")
+    description: z.string().optional().nullish().describe("Description of the board"),
+    sharingPolicy: z.enum(['private', 'view', 'comment', 'edit']).optional().nullish().describe("Sharing policy for the board"),
+    teamId: z.string().optional().nullish().describe("Team ID to assign the board to")
   },
   fn: async ({ name, description, sharingPolicy, teamId }) => {
     try {

--- a/src/tools/createBoardExportJob.ts
+++ b/src/tools/createBoardExportJob.ts
@@ -10,7 +10,7 @@ const createBoardExportJobTool: ToolSchema = {
     orgId: z.string().describe("Unique identifier of the organization"),
     requestId: z.string().describe("Unique identifier of the board export job"),
     boardIds: z.array(z.string()).describe("Array of board IDs to export"),
-    format: z.enum(["pdf", "csv"]).optional().describe("Export format (default: pdf)")
+    format: z.enum(["pdf", "csv"]).optional().nullish().describe("Export format (default: pdf)")
   },
   fn: async ({ orgId, requestId, boardIds, format }) => {
     try {

--- a/src/tools/createCardItem.ts
+++ b/src/tools/createCardItem.ts
@@ -13,22 +13,22 @@ const createCardItemTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board where the card will be created"),
     data: z.object({
       title: z.string().describe("Title of the card"),
-      description: z.string().optional().describe("Description of the card"),
-      assigneeId: z.string().optional().describe("User ID of the assignee"),
-      dueDate: z.string().optional().describe("Due date for the card (ISO 8601 format)")
+      description: z.string().optional().nullish().describe("Description of the card"),
+      assigneeId: z.string().optional().nullish().describe("User ID of the assignee"),
+      dueDate: z.string().optional().nullish().describe("Due date for the card (ISO 8601 format)")
     }).describe("The content and configuration of the card"),
     position: z.object({
       x: z.number().describe("X coordinate of the card"),
       y: z.number().describe("Y coordinate of the card")
     }).describe("Position of the card on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Width of the card"),
-      height: z.number().optional().describe("Height of the card"),
-      rotation: z.number().optional().describe("Rotation angle of the card")
-    }).optional().describe("Dimensions of the card"),
+      width: z.number().optional().nullish().describe("Width of the card"),
+      height: z.number().optional().nullish().describe("Height of the card"),
+      rotation: z.number().optional().nullish().describe("Rotation angle of the card")
+    }).optional().nullish().describe("Dimensions of the card"),
     style: z.object({
-      cardTheme: z.string().optional().describe("Color of the card")
-    }).optional().describe("Style configuration of the card")
+      cardTheme: z.string().optional().nullish().describe("Color of the card")
+    }).optional().nullish().describe("Style configuration of the card")
   },
   fn: async ({ boardId, data, position, geometry, style }) => {
     try {

--- a/src/tools/createConnector.ts
+++ b/src/tools/createConnector.ts
@@ -17,12 +17,12 @@ const createConnectorTool: ToolSchema = {
       id: z.string().describe("ID of the item at the end of the connector") 
     }).describe("End item of the connector"),
     style: z.object({
-      strokeColor: z.string().optional().describe("Color of the connector stroke"),
-      strokeWidth: z.number().optional().describe("Width of the connector stroke"),
-      strokeStyle: z.string().optional().describe("Style of the connector stroke (normal, dashed, etc.)"),
-      startStrokeCap: z.string().optional().describe("Start stroke cap style"),
-      endStrokeCap: z.string().optional().describe("End stroke cap style")
-    }).optional().describe("Style configuration of the connector")
+      strokeColor: z.string().optional().nullish().describe("Color of the connector stroke"),
+      strokeWidth: z.number().optional().nullish().describe("Width of the connector stroke"),
+      strokeStyle: z.string().optional().nullish().describe("Style of the connector stroke (normal, dashed, etc.)"),
+      startStrokeCap: z.string().optional().nullish().describe("Start stroke cap style"),
+      endStrokeCap: z.string().optional().nullish().describe("End stroke cap style")
+    }).optional().nullish().describe("Style configuration of the connector")
   },
   fn: async ({ boardId, startItem, endItem, style }) => {
     try {

--- a/src/tools/createDocumentItem.ts
+++ b/src/tools/createDocumentItem.ts
@@ -13,16 +13,16 @@ const createDocumentItemTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board where the document will be created"),
     data: z.object({
       url: z.string().describe("URL of the document to be added to the board"),
-      title: z.string().optional().describe("Title of the document")
+      title: z.string().optional().nullish().describe("Title of the document")
     }).describe("The content and configuration of the document"),
     position: z.object({
       x: z.number().describe("X coordinate of the document"),
       y: z.number().describe("Y coordinate of the document")
     }).describe("Position of the document on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Width of the document"),
-      height: z.number().optional().describe("Height of the document")
-    }).optional().describe("Dimensions of the document")
+      width: z.number().optional().nullish().describe("Width of the document"),
+      height: z.number().optional().nullish().describe("Height of the document")
+    }).optional().nullish().describe("Dimensions of the document")
   },
   fn: async ({ boardId, data, position, geometry }) => {
     try {

--- a/src/tools/createEmbedItem.ts
+++ b/src/tools/createEmbedItem.ts
@@ -13,17 +13,17 @@ const createEmbedItemTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board where the embed will be created"),
     data: z.object({
       url: z.string().describe("URL to be embedded on the board"),
-      mode: z.string().optional().describe("Mode of the embed (normal, inline, etc.)")
+      mode: z.string().optional().nullish().describe("Mode of the embed (normal, inline, etc.)")
     }).describe("The content and configuration of the embed"),
     position: z.object({
       x: z.number().describe("X coordinate of the embed"),
       y: z.number().describe("Y coordinate of the embed"),
-      origin: z.string().optional().describe("Origin of the embed (center, top-left, etc.)"),
-      relativeTo: z.string().optional().describe("Reference point (canvas_center, etc.)")
+      origin: z.string().optional().nullish().describe("Origin of the embed (center, top-left, etc.)"),
+      relativeTo: z.string().optional().nullish().describe("Reference point (canvas_center, etc.)")
     }).describe("Position of the embed on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Width of the embed"),
-      height: z.number().optional().describe("Height of the embed")
+      width: z.number().optional().nullish().describe("Width of the embed"),
+      height: z.number().optional().nullish().describe("Height of the embed")
     })
     .refine(data => data.width !== undefined || data.height !== undefined, {
       message: "Either width or height must be provided"

--- a/src/tools/createFrameItem.ts
+++ b/src/tools/createFrameItem.ts
@@ -12,22 +12,22 @@ const createFrameItemTool: ToolSchema = {
   args: {
     boardId: z.string().describe("Unique identifier (ID) of the board where the frame will be created"),
     data: z.object({
-      title: z.string().optional().describe("Title of the frame. This title appears at the top of the frame."),
-      format: z.string().optional().describe("Format of the frame. Only 'custom' is supported currently."),
-      type: z.string().optional().describe("Type of the frame. Only 'freeform' is supported currently."),
-      showContent: z.boolean().optional().describe("Hide or reveal the content inside a frame (Enterprise plan only).")
+      title: z.string().optional().nullish().describe("Title of the frame. This title appears at the top of the frame."),
+      format: z.string().optional().nullish().describe("Format of the frame. Only 'custom' is supported currently."),
+      type: z.string().optional().nullish().describe("Type of the frame. Only 'freeform' is supported currently."),
+      showContent: z.boolean().optional().nullish().describe("Hide or reveal the content inside a frame (Enterprise plan only).")
     }).describe("The content and configuration of the frame"),
     position: z.object({
       x: z.number().describe("X coordinate of the frame"),
       y: z.number().describe("Y coordinate of the frame")
     }).describe("Position of the frame on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Width of the frame"),
-      height: z.number().optional().describe("Height of the frame")
-    }).optional().describe("Dimensions of the frame"),
+      width: z.number().optional().nullish().describe("Width of the frame"),
+      height: z.number().optional().nullish().describe("Height of the frame")
+    }).optional().nullish().describe("Dimensions of the frame"),
     style: z.object({
-      fillColor: z.string().optional().describe("Fill color for the frame. Hex values like #f5f6f8, #d5f692, etc.")
-    }).optional().describe("Style configuration of the frame")
+      fillColor: z.string().optional().nullish().describe("Fill color for the frame. Hex values like #f5f6f8, #d5f692, etc.")
+    }).optional().nullish().describe("Style configuration of the frame")
   },
   fn: async ({ boardId, data, position, geometry, style }: {
     boardId: string,

--- a/src/tools/createImageItemUsingFileFromDevice.ts
+++ b/src/tools/createImageItemUsingFileFromDevice.ts
@@ -14,10 +14,10 @@ const createImageItemUsingFileFromDeviceTool: ToolSchema = {
     position: z.object({
       x: z.number().describe("X coordinate of the image"),
       y: z.number().describe("Y coordinate of the image"),
-      origin: z.string().optional().describe("Origin of the image (center, top-left, etc.)"),
-      relativeTo: z.string().optional().describe("Reference point (canvas_center, etc.)")
+      origin: z.string().optional().nullish().describe("Origin of the image (center, top-left, etc.)"),
+      relativeTo: z.string().optional().nullish().describe("Reference point (canvas_center, etc.)")
     }).describe("Position of the image on the board"),
-    title: z.string().optional().describe("Title of the image")
+    title: z.string().optional().nullish().describe("Title of the image")
   },
   fn: async ({ boardId, imageData, position, title }) => {
     try {

--- a/src/tools/createImageItemUsingUrl.ts
+++ b/src/tools/createImageItemUsingUrl.ts
@@ -13,18 +13,18 @@ const createImageItemUsingUrlTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board where the image will be created"),
     data: z.object({
       url: z.string().describe("URL of the image to be added to the board"),
-      title: z.string().optional().describe("Title of the image")
+      title: z.string().optional().nullish().describe("Title of the image")
     }).describe("The content and configuration of the image"),
     position: z.object({
       x: z.number().describe("X coordinate of the image"),
       y: z.number().describe("Y coordinate of the image"),
-      origin: z.string().optional().describe("Origin of the image (center, top-left, etc.)"),
-      relativeTo: z.string().optional().describe("Reference point (canvas_center, etc.)")
+      origin: z.string().optional().nullish().describe("Origin of the image (center, top-left, etc.)"),
+      relativeTo: z.string().optional().nullish().describe("Reference point (canvas_center, etc.)")
     }).describe("Position of the image on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Width of the image"),
-      height: z.number().optional().describe("Height of the image")
-    }).optional().describe("Dimensions of the image")
+      width: z.number().optional().nullish().describe("Width of the image"),
+      height: z.number().optional().nullish().describe("Height of the image")
+    }).optional().nullish().describe("Dimensions of the image")
   },
   fn: async ({ boardId, data, position, geometry }) => {
     try {

--- a/src/tools/createItemsInBulk.ts
+++ b/src/tools/createItemsInBulk.ts
@@ -26,34 +26,34 @@ const stickyNoteSchema = z.object({
   type: z.literal('sticky_note'),
   data: z.object({
     content: z.string().describe("Text content of the sticky note"),
-    shape: z.enum(['square', 'rectangle']).optional().describe("Shape of the sticky note")
+    shape: z.enum(['square', 'rectangle']).optional().nullish().describe("Shape of the sticky note")
   }),
   position: z.object({
     x: z.number().describe("X coordinate"),
     y: z.number().describe("Y coordinate")
   }),
   style: z.object({
-    fillColor: z.string().optional().describe("Fill color of the sticky note"),
-    textAlign: z.enum(['left', 'center', 'right']).optional().describe("Text alignment")
-  }).optional()
+    fillColor: z.string().optional().nullish().describe("Fill color of the sticky note"),
+    textAlign: z.enum(['left', 'center', 'right']).optional().nullish().describe("Text alignment")
+  }).optional().nullish()
 });
 
 const cardSchema = z.object({
   type: z.literal('card'),
   data: z.object({
     title: z.string().describe("Title of the card"),
-    description: z.string().optional().describe("Description of the card"),
-    assigneeId: z.string().optional().describe("User ID of the assignee"),
-    dueDate: z.string().optional().describe("Due date in ISO 8601 format")
+    description: z.string().optional().nullish().describe("Description of the card"),
+    assigneeId: z.string().optional().nullish().describe("User ID of the assignee"),
+    dueDate: z.string().optional().nullish().describe("Due date in ISO 8601 format")
   }),
   position: z.object({
     x: z.number().describe("X coordinate"),
     y: z.number().describe("Y coordinate")
   }),
   style: z.object({
-    fillColor: z.string().optional().describe("Fill color"),
-    textColor: z.string().optional().describe("Text color")
-  }).optional()
+    fillColor: z.string().optional().nullish().describe("Fill color"),
+    textColor: z.string().optional().nullish().describe("Text color")
+  }).optional().nullish()
 });
 
 const textSchema = z.object({
@@ -66,10 +66,10 @@ const textSchema = z.object({
     y: z.number().describe("Y coordinate")
   }),
   style: z.object({
-    color: z.string().optional().describe("Text color (hex format, e.g. #000000)"),
-    fontSize: z.number().optional().describe("Font size"),
-    textAlign: z.enum(['left', 'center', 'right']).optional().describe("Text alignment")
-  }).optional()
+    color: z.string().optional().nullish().describe("Text color (hex format, e.g. #000000)"),
+    fontSize: z.number().optional().nullish().describe("Font size"),
+    textAlign: z.enum(['left', 'center', 'right']).optional().nullish().describe("Text alignment")
+  }).optional().nullish()
 });
 
 const itemSchema = z.discriminatedUnion('type', [

--- a/src/tools/createMindmapNode.ts
+++ b/src/tools/createMindmapNode.ts
@@ -10,11 +10,11 @@ const createMindmapNodeTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board where you want to create the node"),
     data: z.object({
       content: z.string().describe("Text content for the mind map node"),
-      parentId: z.string().optional().describe("ID of the parent node (if this is a child node)"),
+      parentId: z.string().optional().nullish().describe("ID of the parent node (if this is a child node)"),
       style: z.object({
-        fillColor: z.string().optional().describe("Fill color for the node"),
-        textColor: z.string().optional().describe("Text color for the node")
-      }).optional()
+        fillColor: z.string().optional().nullish().describe("Fill color for the node"),
+        textColor: z.string().optional().nullish().describe("Text color for the node")
+      }).optional().nullish()
     }).describe("The content and style configuration of the mind map node"),
     position: z.object({
       x: z.number().describe("X coordinate of the node"),

--- a/src/tools/createShapeItem.ts
+++ b/src/tools/createShapeItem.ts
@@ -15,7 +15,7 @@ const createShapeItemTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board where the shape will be created"),
     data: z.object({
       shape: z.string().describe("Type of the shape (rectangle, circle, triangle, etc.)"),
-      content: z.string().optional().describe("Text content to display inside the shape")
+      content: z.string().optional().nullish().describe("Text content to display inside the shape")
     }).describe("The content and configuration of the shape"),
     position: z.object({
       x: z.number().describe("X coordinate of the shape"),
@@ -24,17 +24,17 @@ const createShapeItemTool: ToolSchema = {
     geometry: z.object({
       width: z.number().describe("Width of the shape"),
       height: z.number().describe("Height of the shape"),
-      rotation: z.number().optional().describe("Rotation angle of the shape")
+      rotation: z.number().optional().nullish().describe("Rotation angle of the shape")
     }).describe("Dimensions of the shape"),
     style: z.object({
-      borderColor: z.string().optional().describe("Color of the shape border (hex format, e.g. #000000)"),
-      borderWidth: z.number().optional().describe("Width of the shape border"),
-      borderStyle: z.string().optional().describe("Style of the shape border (normal, dashed, etc.)"),
-      borderOpacity: z.number().optional().describe("Opacity of the shape border (0-1)"),
-      fillColor: z.string().optional().describe("Fill color of the shape (hex format, e.g. #000000)"),
-      fillOpacity: z.number().optional().describe("Opacity of the shape fill (0-1)"),
-      color: z.string().optional().describe("Color of the text in the shape (hex format, e.g. #000000)")
-    }).optional().describe("Style configuration of the shape")
+      borderColor: z.string().optional().nullish().describe("Color of the shape border (hex format, e.g. #000000)"),
+      borderWidth: z.number().optional().nullish().describe("Width of the shape border"),
+      borderStyle: z.string().optional().nullish().describe("Style of the shape border (normal, dashed, etc.)"),
+      borderOpacity: z.number().optional().nullish().describe("Opacity of the shape border (0-1)"),
+      fillColor: z.string().optional().nullish().describe("Fill color of the shape (hex format, e.g. #000000)"),
+      fillOpacity: z.number().optional().nullish().describe("Opacity of the shape fill (0-1)"),
+      color: z.string().optional().nullish().describe("Color of the text in the shape (hex format, e.g. #000000)")
+    }).optional().nullish().describe("Style configuration of the shape")
   },
   fn: async ({ boardId, data, position, geometry, style }) => {
     try {

--- a/src/tools/createStickyNoteItem.ts
+++ b/src/tools/createStickyNoteItem.ts
@@ -26,22 +26,22 @@ const createStickyNoteItemTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board where the sticky note will be created"),
     data: z.object({
       content: z.string().describe("Text content of the sticky note"),
-      shape: z.string().optional().describe("Shape of the sticky note (square, rectangle, circle, triangle, rhombus)")
+      shape: z.string().optional().nullish().describe("Shape of the sticky note (square, rectangle, circle, triangle, rhombus)")
     }).describe("The content and configuration of the sticky note"),
     position: z.object({
       x: z.number().describe("X coordinate of the sticky note"),
       y: z.number().describe("Y coordinate of the sticky note"),
-      origin: z.string().optional().describe("Origin of the sticky note (center, top-left, etc.)"),
-      relativeTo: z.string().optional().describe("Reference point (canvas_center, etc.)")
+      origin: z.string().optional().nullish().describe("Origin of the sticky note (center, top-left, etc.)"),
+      relativeTo: z.string().optional().nullish().describe("Reference point (canvas_center, etc.)")
     }).describe("Position of the sticky note on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Width of the sticky note"),
-      height: z.number().optional().describe("Height of the sticky note")
-    }).optional().describe("Dimensions of the sticky note"),
+      width: z.number().optional().nullish().describe("Width of the sticky note"),
+      height: z.number().optional().nullish().describe("Height of the sticky note")
+    }).optional().nullish().describe("Dimensions of the sticky note"),
     style: z.object({
-      fillColor: z.string().optional().describe("Fill color of the sticky note (use predefined values like 'light_yellow', 'light_green', etc.)"),
-      textAlign: z.string().optional().describe("Alignment of the text (left, center, right)")
-    }).optional().describe("Style configuration of the sticky note")
+      fillColor: z.string().optional().nullish().describe("Fill color of the sticky note (use predefined values like 'light_yellow', 'light_green', etc.)"),
+      textAlign: z.string().optional().nullish().describe("Alignment of the text (left, center, right)")
+    }).optional().nullish().describe("Style configuration of the sticky note")
   },
   fn: async ({ boardId, data, position, geometry, style }) => {
     try {

--- a/src/tools/createTag.ts
+++ b/src/tools/createTag.ts
@@ -13,7 +13,7 @@ const createTagTool: ToolSchema = {
     data: z.object({
       title: z.string().describe("Title of the tag")
     }).describe("The content and configuration of the tag"),
-    fillColor: z.string().optional().describe("Fill color of the tag (hex format, e.g. #000000)")
+    fillColor: z.string().optional().nullish().describe("Fill color of the tag (hex format, e.g. #000000)")
   },
   fn: async ({ boardId, data, fillColor }) => {
     try {

--- a/src/tools/createTextItem.ts
+++ b/src/tools/createTextItem.ts
@@ -19,13 +19,13 @@ const createTextItemTool: ToolSchema = {
       y: z.number().describe("Y coordinate of the text item")
     }).describe("Position of the text item on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Width of the text item")
-    }).optional().describe("Dimensions of the text item"),
+      width: z.number().optional().nullish().describe("Width of the text item")
+    }).optional().nullish().describe("Dimensions of the text item"),
     style: z.object({
-      color: z.string().optional().describe("Color of the text"),
-      fontSize: z.number().optional().describe("Font size of the text"),
-      textAlign: z.string().optional().describe("Alignment of the text (left, center, right)")
-    }).optional().describe("Style configuration of the text item")
+      color: z.string().optional().nullish().describe("Color of the text"),
+      fontSize: z.number().optional().nullish().describe("Font size of the text"),
+      textAlign: z.string().optional().nullish().describe("Alignment of the text (left, center, right)")
+    }).optional().nullish().describe("Style configuration of the text item")
   },
   fn: async ({ boardId, data, position, geometry, style }) => {
     try {

--- a/src/tools/deleteGroup.ts
+++ b/src/tools/deleteGroup.ts
@@ -9,7 +9,7 @@ const deleteGroupTool: ToolSchema = {
   args: {
     boardId: z.string().describe("ID of the board that contains the group"),
     groupId: z.string().describe("ID of the group that you want to delete"),
-    deleteItems: z.boolean().optional().describe("Indicates whether the items should be removed. Set to true to delete items in the group, false to keep them")
+    deleteItems: z.boolean().optional().nullish().describe("Indicates whether the items should be removed. Set to true to delete items in the group, false to keep them")
   },
   fn: async ({ boardId, groupId, deleteItems }) => {
     try {

--- a/src/tools/getAllBoardMembers.ts
+++ b/src/tools/getAllBoardMembers.ts
@@ -8,8 +8,8 @@ const getAllBoardMembersTool: ToolSchema = {
   description: "Retrieve all members of a specific Miro board",
   args: {
     boardId: z.string().describe("ID of the board to retrieve members from"),
-    limit: z.number().optional().describe("Maximum number of members to retrieve (default: 50)"),
-    offset: z.number().optional().describe("Offset for pagination (default: 0)")
+    limit: z.number().optional().nullish().describe("Maximum number of members to retrieve (default: 50)"),
+    offset: z.number().optional().nullish().describe("Offset for pagination (default: 0)")
   },
   fn: async ({ boardId, limit = 50, offset = 0 }) => {
     try {

--- a/src/tools/getAllCases.ts
+++ b/src/tools/getAllCases.ts
@@ -9,7 +9,7 @@ const getAllCasesTool: ToolSchema = {
   args: {
     limit: z.number().describe("The maximum number of items in the result list"),
     orgId: z.string().describe("The ID of the organization for which you want to retrieve the list of cases"),
-    cursor: z.string().optional().describe("Cursor for pagination")
+    cursor: z.string().optional().nullish().describe("Cursor for pagination")
   },
   fn: async ({ limit, orgId, cursor }) => {
     try {

--- a/src/tools/getAllGroups.ts
+++ b/src/tools/getAllGroups.ts
@@ -8,8 +8,8 @@ const getAllGroupsTool: ToolSchema = {
   description: "Retrieve all groups on a Miro board",
   args: {
     boardId: z.string().describe("ID of the board whose groups you want to retrieve"),
-    limit: z.number().optional().describe("Maximum number of groups to return (default: 50)"),
-    cursor: z.string().optional().describe("Cursor for pagination")
+    limit: z.number().optional().nullish().describe("Maximum number of groups to return (default: 50)"),
+    cursor: z.string().optional().nullish().describe("Cursor for pagination")
   },
   fn: async ({ boardId, limit, cursor }) => {
     try {

--- a/src/tools/getAllLegalHolds.ts
+++ b/src/tools/getAllLegalHolds.ts
@@ -10,7 +10,7 @@ const getLegalHoldsTool: ToolSchema = {
     limit: z.number().describe("The maximum number of items in the result list"),
     orgId: z.string().describe("The ID of the organization for which you want to retrieve the list of legal holds"),
     caseId: z.string().describe("The ID of the case for which you want to retrieve the list of legal holds"),
-    cursor: z.string().optional().describe("Cursor for pagination")
+    cursor: z.string().optional().nullish().describe("Cursor for pagination")
   },
   fn: async ({ limit, orgId, caseId, cursor }) => {
     try {

--- a/src/tools/getAllTags.ts
+++ b/src/tools/getAllTags.ts
@@ -8,8 +8,8 @@ const getAllTagsTool: ToolSchema = {
   description: "Retrieve all tags on a Miro board",
   args: {
     boardId: z.string().describe("Unique identifier (ID) of the board for which you want to retrieve all tags"),
-    limit: z.number().optional().describe("Maximum number of tags to return (default: 50)"),
-    offset: z.number().optional().describe("Offset for pagination (default: 0)")
+    limit: z.number().optional().nullish().describe("Maximum number of tags to return (default: 50)"),
+    offset: z.number().optional().nullish().describe("Offset for pagination (default: 0)")
   },
   fn: async ({ boardId, limit, offset }) => {
     try {

--- a/src/tools/getAuditLogs.ts
+++ b/src/tools/getAuditLogs.ts
@@ -9,9 +9,9 @@ const getAuditLogsTool: ToolSchema = {
   args: {
     createdAfter: z.string().describe("Retrieve audit logs created after this date (ISO 8601 format)"),
     createdBefore: z.string().describe("Retrieve audit logs created before this date (ISO 8601 format)"),
-    cursor: z.string().optional().describe("Cursor for pagination"),
-    limit: z.number().optional().describe("Maximum number of results to return (default: 100)"),
-    sorting: z.enum(["ASC", "DESC"]).optional().describe("Sort order for results (default: ASC)")
+    cursor: z.string().optional().nullish().describe("Cursor for pagination"),
+    limit: z.number().optional().nullish().describe("Maximum number of results to return (default: 100)"),
+    sorting: z.enum(["ASC", "DESC"]).optional().nullish().describe("Sort order for results (default: ASC)")
   },
   fn: async ({ createdAfter, createdBefore, cursor, limit, sorting }) => {
     try {

--- a/src/tools/getBoardContentLogs.ts
+++ b/src/tools/getBoardContentLogs.ts
@@ -10,11 +10,11 @@ const getBoardContentLogsTool: ToolSchema = {
     orgId: z.string().describe("Unique identifier of the organization"),
     from: z.string().describe("Start date for filtering (ISO 8601 format)"),
     to: z.string().describe("End date for filtering (ISO 8601 format)"),
-    boardIds: z.array(z.string()).optional().describe("List of board IDs to filter by"),
-    emails: z.array(z.string()).optional().describe("List of user emails to filter by"),
-    cursor: z.string().optional().describe("Cursor for pagination"),
-    limit: z.number().optional().describe("Maximum number of results to return"),
-    sorting: z.enum(["asc", "desc"]).optional().describe("Sort order for results")
+    boardIds: z.array(z.string()).optional().nullish().describe("List of board IDs to filter by"),
+    emails: z.array(z.string()).optional().nullish().describe("List of user emails to filter by"),
+    cursor: z.string().optional().nullish().describe("Cursor for pagination"),
+    limit: z.number().optional().nullish().describe("Maximum number of results to return"),
+    sorting: z.enum(["asc", "desc"]).optional().nullish().describe("Sort order for results")
   },
   fn: async ({ orgId, from, to, boardIds, emails, cursor, limit, sorting }) => {
     try {

--- a/src/tools/getConnectors.ts
+++ b/src/tools/getConnectors.ts
@@ -8,8 +8,8 @@ const getConnectorsTool: ToolSchema = {
   description: "Retrieve all connectors on a specific Miro board",
   args: {
     boardId: z.string().describe("Unique identifier (ID) of the board whose connectors you want to retrieve"),
-    limit: z.number().optional().describe("Maximum number of connectors to return (default: 50)"),
-    cursor: z.string().optional().describe("Cursor for pagination")
+    limit: z.number().optional().nullish().describe("Maximum number of connectors to return (default: 50)"),
+    cursor: z.string().optional().nullish().describe("Cursor for pagination")
   },
   fn: async ({ boardId, limit, cursor }) => {
     try {

--- a/src/tools/getGroupItems.ts
+++ b/src/tools/getGroupItems.ts
@@ -9,8 +9,8 @@ const getGroupItemsTool: ToolSchema = {
   args: {
     boardId: z.string().describe("ID of the board that contains the group"),
     groupId: z.string().describe("ID of the group whose items you want to retrieve"),
-    limit: z.number().optional().describe("Maximum number of items to return (default: 50)"),
-    cursor: z.string().optional().describe("Cursor for pagination")
+    limit: z.number().optional().nullish().describe("Maximum number of items to return (default: 50)"),
+    cursor: z.string().optional().nullish().describe("Cursor for pagination")
   },
   fn: async ({ boardId, groupId, limit, cursor }) => {
     try {

--- a/src/tools/getItemsOnBoard.ts
+++ b/src/tools/getItemsOnBoard.ts
@@ -8,8 +8,8 @@ const getItemsOnBoardTool: ToolSchema = {
   description: "Retrieve all items on a specific Miro board",
   args: {
     boardId: z.string().describe("Unique identifier (ID) of the board whose items you want to retrieve"),
-    limit: z.number().optional().describe("Maximum number of items to return (default: 50)"),
-    offset: z.number().optional().describe("Offset for pagination (default: 0)")
+    limit: z.number().optional().nullish().describe("Maximum number of items to return (default: 50)"),
+    offset: z.number().optional().nullish().describe("Offset for pagination (default: 0)")
   },
   fn: async ({ boardId, limit = 50, offset = 0 }) => {
     try {

--- a/src/tools/getLegalHoldContentItems.ts
+++ b/src/tools/getLegalHoldContentItems.ts
@@ -11,7 +11,7 @@ const getLegalHoldContentItemsTool: ToolSchema = {
     caseId: z.string().describe("The ID of the case for which you want to retrieve the list of content items under hold"),
     legalHoldId: z.string().describe("The ID of the legal hold for which you want to retrieve the list of content items under hold"),
     limit: z.number().describe("The maximum number of items in the result list"),
-    cursor: z.string().optional().describe("Cursor for pagination")
+    cursor: z.string().optional().nullish().describe("Cursor for pagination")
   },
   fn: async ({ orgId, caseId, legalHoldId, limit, cursor }) => {
     try {

--- a/src/tools/getMindmapNodes.ts
+++ b/src/tools/getMindmapNodes.ts
@@ -8,8 +8,8 @@ const getMindmapNodesTool: ToolSchema = {
   description: "Retrieve a list of mind map nodes on a Miro board",
   args: {
     boardId: z.string().describe("Unique identifier (ID) of the board from which you want to retrieve mind map nodes"),
-    limit: z.number().optional().describe("Maximum number of results to return (default: 50)"),
-    cursor: z.string().optional().describe("Cursor for pagination")
+    limit: z.number().optional().nullish().describe("Maximum number of results to return (default: 50)"),
+    cursor: z.string().optional().nullish().describe("Cursor for pagination")
   },
   fn: async ({ boardId, limit, cursor }) => {
     try {

--- a/src/tools/getOrganizationMembers.ts
+++ b/src/tools/getOrganizationMembers.ts
@@ -8,12 +8,12 @@ const getOrganizationMembersTool: ToolSchema = {
   description: "Retrieves a list of members for an organization (Enterprise only)",
   args: {
     orgId: z.string().describe("id of the organization"),
-    emails: z.string().optional().describe("Filter by comma-separated email addresses"),
-    role: z.enum(['organization_internal_admin', 'organization_internal_user', 'organization_external_user', 'organization_team_guest_user', 'unknown']).optional().describe("Filter by user role"),
-    license: z.enum(['full', 'occasional', 'free', 'free_restricted', 'full_trial', 'unknown']).optional().describe("Filter by license type"),
-    active: z.boolean().optional().describe("Filter by active status"),
-    cursor: z.string().optional().describe("Cursor for pagination"),
-    limit: z.number().optional().describe("Maximum number of results to return")
+    emails: z.string().optional().nullish().describe("Filter by comma-separated email addresses"),
+    role: z.enum(['organization_internal_admin', 'organization_internal_user', 'organization_external_user', 'organization_team_guest_user', 'unknown']).optional().nullish().describe("Filter by user role"),
+    license: z.enum(['full', 'occasional', 'free', 'free_restricted', 'full_trial', 'unknown']).optional().nullish().describe("Filter by license type"),
+    active: z.boolean().optional().nullish().describe("Filter by active status"),
+    cursor: z.string().optional().nullish().describe("Cursor for pagination"),
+    limit: z.number().optional().nullish().describe("Maximum number of results to return")
   },
   fn: async ({ orgId, emails, role, license, active, cursor, limit }) => {
     try {

--- a/src/tools/listBoards.ts
+++ b/src/tools/listBoards.ts
@@ -7,8 +7,8 @@ const listBoardsTool: ToolSchema = {
   name: "list-boards",
   description: "List all available Miro boards",
   args: {
-    limit: z.number().optional().describe("Maximum number of boards to return (default: 50)"),
-    offset: z.number().optional().describe("Offset for pagination (default: 0)")
+    limit: z.number().optional().nullish().describe("Maximum number of boards to return (default: 50)"),
+    offset: z.number().optional().nullish().describe("Offset for pagination (default: 0)")
   },
   fn: async ({ limit = 50, offset = 0 }) => {
     try {

--- a/src/tools/shareBoard.ts
+++ b/src/tools/shareBoard.ts
@@ -9,7 +9,7 @@ const shareBoardTool: ToolSchema = {
   args: {
     boardId: z.string().describe("ID of the board to share"),
     accessLevel: z.enum(['private', 'view', 'comment', 'edit']).describe("Access level for shared board"),
-    teamId: z.string().optional().describe("Team ID to assign the board to"),
+    teamId: z.string().optional().nullish().describe("Team ID to assign the board to"),
   },
   fn: async ({ boardId, accessLevel, teamId }) => {
     try {

--- a/src/tools/ungroupItems.ts
+++ b/src/tools/ungroupItems.ts
@@ -9,7 +9,7 @@ const ungroupItemsTool: ToolSchema = {
   args: {
     boardId: z.string().describe("ID of the board that contains the group"),
     groupId: z.string().describe("ID of the group that you want to ungroup"),
-    deleteItems: z.boolean().optional().describe("Indicates whether the items should be removed. By default, false.")
+    deleteItems: z.boolean().optional().nullish().describe("Indicates whether the items should be removed. By default, false.")
   },
   fn: async ({ boardId, groupId, deleteItems }) => {
     try {

--- a/src/tools/updateAppCardItem.ts
+++ b/src/tools/updateAppCardItem.ts
@@ -14,24 +14,24 @@ const updateAppCardItemTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board that contains the app card"),
     itemId: z.string().describe("Unique identifier (ID) of the app card that you want to update"),
     data: z.object({
-      title: z.string().optional().describe("Updated title of the app card"),
-      description: z.string().optional().describe("Updated description of the app card"),
-      status: z.string().optional().describe("Updated status text of the app card"),
+      title: z.string().optional().nullish().describe("Updated title of the app card"),
+      description: z.string().optional().nullish().describe("Updated description of the app card"),
+      status: z.string().optional().nullish().describe("Updated status text of the app card"),
       fields: z.array(z.object({
         value: z.string().describe("Value of the field"),
-        iconShape: z.string().optional().describe("Shape of the icon"),
-        fillColor: z.string().optional().describe("Fill color of the field"),
-        textColor: z.string().optional().describe("Color of the text"),
-      })).optional().describe("Updated custom fields to display on the app card")
-    }).optional().describe("The updated content and configuration of the app card"),
+        iconShape: z.string().optional().nullish().describe("Shape of the icon"),
+        fillColor: z.string().optional().nullish().describe("Fill color of the field"),
+        textColor: z.string().optional().nullish().describe("Color of the text"),
+      })).optional().nullish().describe("Updated custom fields to display on the app card")
+    }).optional().nullish().describe("The updated content and configuration of the app card"),
     position: z.object({
       x: z.number().describe("Updated X coordinate of the app card"),
       y: z.number().describe("Updated Y coordinate of the app card")
-    }).optional().describe("Updated position of the app card on the board"),
+    }).optional().nullish().describe("Updated position of the app card on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Updated width of the app card"),
-      height: z.number().optional().describe("Updated height of the app card")
-    }).optional().describe("Updated dimensions of the app card")
+      width: z.number().optional().nullish().describe("Updated width of the app card"),
+      height: z.number().optional().nullish().describe("Updated height of the app card")
+    }).optional().nullish().describe("Updated dimensions of the app card")
   },
   fn: async ({ boardId, itemId, data, position, geometry }) => {
     try {

--- a/src/tools/updateBoard.ts
+++ b/src/tools/updateBoard.ts
@@ -8,10 +8,10 @@ const updateBoardTool: ToolSchema = {
   description: "Update an existing Miro board with new settings",
   args: {
     boardId: z.string().describe("Unique identifier (ID) of the board that you want to update"),
-    name: z.string().optional().describe("New name for the board"),
-    description: z.string().optional().describe("New description for the board"),
-    sharingPolicy: z.enum(['private', 'view', 'comment', 'edit']).optional().describe("New sharing policy for the board"),
-    teamId: z.string().optional().describe("New team ID to assign the board to")
+    name: z.string().optional().nullish().describe("New name for the board"),
+    description: z.string().optional().nullish().describe("New description for the board"),
+    sharingPolicy: z.enum(['private', 'view', 'comment', 'edit']).optional().nullish().describe("New sharing policy for the board"),
+    teamId: z.string().optional().nullish().describe("New team ID to assign the board to")
   },
   fn: async ({ boardId, name, description, sharingPolicy, teamId }) => {
     try {

--- a/src/tools/updateBoardMember.ts
+++ b/src/tools/updateBoardMember.ts
@@ -9,8 +9,8 @@ const updateBoardMemberTool: ToolSchema = {
   args: {
     boardId: z.string().describe("ID of the board"),
     memberId: z.string().describe("ID of the board member to update"),
-    role: z.enum(['member', 'admin', 'owner']).optional().describe("New role for the board member"),
-    status: z.enum(['active', 'pending', 'blocked']).optional().describe("New status for the board member")
+    role: z.enum(['member', 'admin', 'owner']).optional().nullish().describe("New role for the board member"),
+    status: z.enum(['active', 'pending', 'blocked']).optional().nullish().describe("New status for the board member")
   },
   fn: async ({ boardId, memberId, role, status }) => {
     try {

--- a/src/tools/updateCardItem.ts
+++ b/src/tools/updateCardItem.ts
@@ -13,23 +13,23 @@ const updateCardItemTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board that contains the card"),
     itemId: z.string().describe("Unique identifier (ID) of the card that you want to update"),
     data: z.object({
-      title: z.string().optional().describe("Updated title of the card"),
-      description: z.string().optional().describe("Updated description of the card"),
-      assigneeId: z.string().optional().describe("Updated user ID of the assignee"),
-      dueDate: z.string().optional().describe("Updated due date for the card (ISO 8601 format)")
-    }).optional().describe("The updated content and configuration of the card"),
+      title: z.string().optional().nullish().describe("Updated title of the card"),
+      description: z.string().optional().nullish().describe("Updated description of the card"),
+      assigneeId: z.string().optional().nullish().describe("Updated user ID of the assignee"),
+      dueDate: z.string().optional().nullish().describe("Updated due date for the card (ISO 8601 format)")
+    }).optional().nullish().describe("The updated content and configuration of the card"),
     position: z.object({
       x: z.number().describe("Updated X coordinate of the card"),
       y: z.number().describe("Updated Y coordinate of the card")
-    }).optional().describe("Updated position of the card on the board"),
+    }).optional().nullish().describe("Updated position of the card on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Updated width of the card"),
-      height: z.number().optional().describe("Updated height of the card"),
-      rotation: z.number().optional().describe("Updated rotation angle of the card")
-    }).optional().describe("Updated dimensions of the card"),
+      width: z.number().optional().nullish().describe("Updated width of the card"),
+      height: z.number().optional().nullish().describe("Updated height of the card"),
+      rotation: z.number().optional().nullish().describe("Updated rotation angle of the card")
+    }).optional().nullish().describe("Updated dimensions of the card"),
     style: z.object({
-      cardTheme: z.string().optional().describe("Updated color of the card")
-    }).optional().describe("Updated style configuration of the card")
+      cardTheme: z.string().optional().nullish().describe("Updated color of the card")
+    }).optional().nullish().describe("Updated style configuration of the card")
   },
   fn: async ({ boardId, itemId, data, position, geometry, style }) => {
     try {

--- a/src/tools/updateConnector.ts
+++ b/src/tools/updateConnector.ts
@@ -13,17 +13,17 @@ const updateConnectorTool: ToolSchema = {
     connectorId: z.string().describe("Unique identifier (ID) of the connector that you want to update"),
     startItem: z.object({
       id: z.string().describe("ID of the item at the start of the connector")
-    }).optional().describe("Start item of the connector"),
+    }).optional().nullish().describe("Start item of the connector"),
     endItem: z.object({
       id: z.string().describe("ID of the item at the end of the connector")
-    }).optional().describe("End item of the connector"),
+    }).optional().nullish().describe("End item of the connector"),
     style: z.object({
-      strokeColor: z.string().optional().describe("Updated color of the connector stroke"),
-      strokeWidth: z.number().optional().describe("Updated width of the connector stroke"),
-      strokeStyle: z.string().optional().describe("Updated style of the connector stroke (normal, dashed, etc.)"),
-      startStrokeCap: z.string().optional().describe("Updated start stroke cap style"),
-      endStrokeCap: z.string().optional().describe("Updated end stroke cap style")
-    }).optional().describe("Updated style configuration of the connector")
+      strokeColor: z.string().optional().nullish().describe("Updated color of the connector stroke"),
+      strokeWidth: z.number().optional().nullish().describe("Updated width of the connector stroke"),
+      strokeStyle: z.string().optional().nullish().describe("Updated style of the connector stroke (normal, dashed, etc.)"),
+      startStrokeCap: z.string().optional().nullish().describe("Updated start stroke cap style"),
+      endStrokeCap: z.string().optional().nullish().describe("Updated end stroke cap style")
+    }).optional().nullish().describe("Updated style configuration of the connector")
   },
   fn: async ({ boardId, connectorId, startItem, endItem, style }) => {
     try {

--- a/src/tools/updateDocumentItem.ts
+++ b/src/tools/updateDocumentItem.ts
@@ -12,17 +12,17 @@ const updateDocumentItemTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board that contains the document"),
     itemId: z.string().describe("Unique identifier (ID) of the document that you want to update"),
     data: z.object({
-      url: z.string().optional().describe("Updated URL of the document"),
-      title: z.string().optional().describe("Updated title of the document")
-    }).optional().describe("The updated content and configuration of the document"),
+      url: z.string().optional().nullish().describe("Updated URL of the document"),
+      title: z.string().optional().nullish().describe("Updated title of the document")
+    }).optional().nullish().describe("The updated content and configuration of the document"),
     position: z.object({
-      x: z.number().optional().describe("Updated X coordinate of the document"),
-      y: z.number().optional().describe("Updated Y coordinate of the document")
-    }).optional().describe("Updated position of the document on the board"),
+      x: z.number().optional().nullish().describe("Updated X coordinate of the document"),
+      y: z.number().optional().nullish().describe("Updated Y coordinate of the document")
+    }).optional().nullish().describe("Updated position of the document on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Updated width of the document"),
-      height: z.number().optional().describe("Updated height of the document")
-    }).optional().describe("Updated dimensions of the document")
+      width: z.number().optional().nullish().describe("Updated width of the document"),
+      height: z.number().optional().nullish().describe("Updated height of the document")
+    }).optional().nullish().describe("Updated dimensions of the document")
   },
   fn: async ({ boardId, itemId, data, position, geometry }) => {
     try {

--- a/src/tools/updateEmbedItem.ts
+++ b/src/tools/updateEmbedItem.ts
@@ -10,19 +10,19 @@ const updateEmbedItemTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board that contains the embed"),
     itemId: z.string().describe("Unique identifier (ID) of the embed that you want to update"),
     data: z.object({
-      mode: z.string().optional().describe("Updated mode of the embed (normal, inline, etc.)")
-    }).optional().describe("The updated configuration of the embed"),
+      mode: z.string().optional().nullish().describe("Updated mode of the embed (normal, inline, etc.)")
+    }).optional().nullish().describe("The updated configuration of the embed"),
     position: z.object({
       x: z.number().describe("Updated X coordinate of the embed"),
       y: z.number().describe("Updated Y coordinate of the embed"),
-      origin: z.string().optional().describe("Origin of the embed (center, top-left, etc.)"),
-      relativeTo: z.string().optional().describe("Reference point (canvas_center, etc.)")
-    }).optional().describe("Updated position of the embed on the board"),
+      origin: z.string().optional().nullish().describe("Origin of the embed (center, top-left, etc.)"),
+      relativeTo: z.string().optional().nullish().describe("Reference point (canvas_center, etc.)")
+    }).optional().nullish().describe("Updated position of the embed on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Updated width of the embed"),
-      height: z.number().optional().describe("Updated height of the embed")
+      width: z.number().optional().nullish().describe("Updated width of the embed"),
+      height: z.number().optional().nullish().describe("Updated height of the embed")
     })
-    .optional()
+    .optional().nullish()
     .refine(data => !data || data.width !== undefined || data.height !== undefined, {
       message: "Either width or height must be provided if geometry is set"
     })

--- a/src/tools/updateFrameItem.ts
+++ b/src/tools/updateFrameItem.ts
@@ -13,22 +13,22 @@ const updateFrameItemTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board where you want to update the frame"),
     itemId: z.string().describe("Unique identifier (ID) of the frame that you want to update"),
     data: z.object({
-      title: z.string().optional().describe("Title of the frame. This title appears at the top of the frame."),
-      format: z.string().optional().describe("Format of the frame. Only 'custom' is supported currently."),
-      type: z.string().optional().describe("Type of the frame. Only 'freeform' is supported currently."),
-      showContent: z.boolean().optional().describe("Hide or reveal the content inside a frame (Enterprise plan only).")
-    }).optional().describe("The updated content and configuration of the frame"),
+      title: z.string().optional().nullish().describe("Title of the frame. This title appears at the top of the frame."),
+      format: z.string().optional().nullish().describe("Format of the frame. Only 'custom' is supported currently."),
+      type: z.string().optional().nullish().describe("Type of the frame. Only 'freeform' is supported currently."),
+      showContent: z.boolean().optional().nullish().describe("Hide or reveal the content inside a frame (Enterprise plan only).")
+    }).optional().nullish().describe("The updated content and configuration of the frame"),
     position: z.object({
       x: z.number().describe("X coordinate of the frame"),
       y: z.number().describe("Y coordinate of the frame")
-    }).optional().describe("Updated position of the frame on the board"),
+    }).optional().nullish().describe("Updated position of the frame on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Width of the frame"),
-      height: z.number().optional().describe("Height of the frame")
-    }).optional().describe("Updated dimensions of the frame"),
+      width: z.number().optional().nullish().describe("Width of the frame"),
+      height: z.number().optional().nullish().describe("Height of the frame")
+    }).optional().nullish().describe("Updated dimensions of the frame"),
     style: z.object({
-      fillColor: z.string().optional().describe("Fill color for the frame. Hex values like #f5f6f8, #d5f692, etc.")
-    }).optional().describe("Updated style configuration of the frame")
+      fillColor: z.string().optional().nullish().describe("Fill color for the frame. Hex values like #f5f6f8, #d5f692, etc.")
+    }).optional().nullish().describe("Updated style configuration of the frame")
   },
   fn: async ({ boardId, itemId, data, position, geometry, style }: {
     boardId: string,

--- a/src/tools/updateImageItem.ts
+++ b/src/tools/updateImageItem.ts
@@ -12,18 +12,18 @@ const updateImageItemTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board where you want to update the item"),
     itemId: z.string().describe("Unique identifier (ID) of the image that you want to update"),
     data: z.object({
-      title: z.string().optional().describe("Updated title of the image")
-    }).optional().describe("The updated content of the image"),
+      title: z.string().optional().nullish().describe("Updated title of the image")
+    }).optional().nullish().describe("The updated content of the image"),
     position: z.object({
-      x: z.number().optional().describe("Updated X coordinate of the image"),
-      y: z.number().optional().describe("Updated Y coordinate of the image"),
-      origin: z.string().optional().describe("Updated origin of the image (center, top-left, etc.)"),
-      relativeTo: z.string().optional().describe("Updated reference point (canvas_center, etc.)")
-    }).optional().describe("Updated position of the image on the board"),
+      x: z.number().optional().nullish().describe("Updated X coordinate of the image"),
+      y: z.number().optional().nullish().describe("Updated Y coordinate of the image"),
+      origin: z.string().optional().nullish().describe("Updated origin of the image (center, top-left, etc.)"),
+      relativeTo: z.string().optional().nullish().describe("Updated reference point (canvas_center, etc.)")
+    }).optional().nullish().describe("Updated position of the image on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Updated width of the image"),
-      height: z.number().optional().describe("Updated height of the image")
-    }).optional().describe("Updated dimensions of the image")
+      width: z.number().optional().nullish().describe("Updated width of the image"),
+      height: z.number().optional().nullish().describe("Updated height of the image")
+    }).optional().nullish().describe("Updated dimensions of the image")
   },
   fn: async ({ boardId, itemId, data, position, geometry }) => {
     try {

--- a/src/tools/updateImageItemUsingFileFromDevice.ts
+++ b/src/tools/updateImageItemUsingFileFromDevice.ts
@@ -14,13 +14,13 @@ const updateImageItemUsingFileFromDeviceTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board where you want to update the item"),
     itemId: z.string().describe("Unique identifier (ID) of the image that you want to update"),
     filePath: z.string().describe("Path to the new image file on the device"),
-    title: z.string().optional().describe("Updated title of the image"),
+    title: z.string().optional().nullish().describe("Updated title of the image"),
     position: z.object({
-      x: z.number().optional().describe("Updated X coordinate of the image"),
-      y: z.number().optional().describe("Updated Y coordinate of the image"),
-      origin: z.string().optional().describe("Updated origin of the image (center, top-left, etc.)"),
-      relativeTo: z.string().optional().describe("Updated reference point (canvas_center, etc.)")
-    }).optional().describe("Updated position of the image on the board")
+      x: z.number().optional().nullish().describe("Updated X coordinate of the image"),
+      y: z.number().optional().nullish().describe("Updated Y coordinate of the image"),
+      origin: z.string().optional().nullish().describe("Updated origin of the image (center, top-left, etc.)"),
+      relativeTo: z.string().optional().nullish().describe("Updated reference point (canvas_center, etc.)")
+    }).optional().nullish().describe("Updated position of the image on the board")
   },
   fn: async ({ boardId, itemId, filePath, title, position }) => {
     try {

--- a/src/tools/updateItemPosition.ts
+++ b/src/tools/updateItemPosition.ts
@@ -10,10 +10,10 @@ const updateItemPositionTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board that contains the item"),
     itemId: z.string().describe("Unique identifier (ID) of the item that you want to update"),
     position: z.object({
-      x: z.number().optional().describe("X coordinate of the item"),
-      y: z.number().optional().describe("Y coordinate of the item")
-    }).optional().describe("New position coordinates for the item"),
-    parentId: z.string().optional().describe("Unique identifier (ID) of the new parent item")
+      x: z.number().optional().nullish().describe("X coordinate of the item"),
+      y: z.number().optional().nullish().describe("Y coordinate of the item")
+    }).optional().nullish().describe("New position coordinates for the item"),
+    parentId: z.string().optional().nullish().describe("Unique identifier (ID) of the new parent item")
   },
   fn: async ({ boardId, itemId, position, parentId }) => {
     try {

--- a/src/tools/updateShapeItem.ts
+++ b/src/tools/updateShapeItem.ts
@@ -10,27 +10,27 @@ const updateShapeItemTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board that contains the shape"),
     itemId: z.string().describe("Unique identifier (ID) of the shape that you want to update"),
     data: z.object({
-      shape: z.string().optional().describe("Updated type of the shape (rectangle, circle, triangle, etc.)"),
-      content: z.string().optional().describe("Updated text content to display inside the shape")
-    }).optional().describe("The updated content and configuration of the shape"),
+      shape: z.string().optional().nullish().describe("Updated type of the shape (rectangle, circle, triangle, etc.)"),
+      content: z.string().optional().nullish().describe("Updated text content to display inside the shape")
+    }).optional().nullish().describe("The updated content and configuration of the shape"),
     position: z.object({
       x: z.number().describe("Updated X coordinate of the shape"),
       y: z.number().describe("Updated Y coordinate of the shape")
-    }).optional().describe("Updated position of the shape on the board"),
+    }).optional().nullish().describe("Updated position of the shape on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Updated width of the shape"),
-      height: z.number().optional().describe("Updated height of the shape"),
-      rotation: z.number().optional().describe("Rotation angle of the shape")
-    }).optional().describe("Updated dimensions of the shape"),
+      width: z.number().optional().nullish().describe("Updated width of the shape"),
+      height: z.number().optional().nullish().describe("Updated height of the shape"),
+      rotation: z.number().optional().nullish().describe("Rotation angle of the shape")
+    }).optional().nullish().describe("Updated dimensions of the shape"),
     style: z.object({
-      borderColor: z.string().optional().describe("Updated color of the shape border (hex format, e.g. #000000)"),
-      borderWidth: z.number().optional().describe("Updated width of the shape border"),
-      borderStyle: z.string().optional().describe("Updated style of the shape border (normal, dashed, etc.)"),
-      borderOpacity: z.number().optional().describe("Updated opacity of the shape border (0-1)"),
-      fillColor: z.string().optional().describe("Updated fill color of the shape (hex format, e.g. #000000)"),
-      fillOpacity: z.number().optional().describe("Updated opacity of the shape fill (0-1)"),
-      color: z.string().optional().describe("Updated color of the text in the shape (hex format, e.g. #000000)")
-    }).optional().describe("Updated style configuration of the shape")
+      borderColor: z.string().optional().nullish().describe("Updated color of the shape border (hex format, e.g. #000000)"),
+      borderWidth: z.number().optional().nullish().describe("Updated width of the shape border"),
+      borderStyle: z.string().optional().nullish().describe("Updated style of the shape border (normal, dashed, etc.)"),
+      borderOpacity: z.number().optional().nullish().describe("Updated opacity of the shape border (0-1)"),
+      fillColor: z.string().optional().nullish().describe("Updated fill color of the shape (hex format, e.g. #000000)"),
+      fillOpacity: z.number().optional().nullish().describe("Updated opacity of the shape fill (0-1)"),
+      color: z.string().optional().nullish().describe("Updated color of the text in the shape (hex format, e.g. #000000)")
+    }).optional().nullish().describe("Updated style configuration of the shape")
   },
   fn: async ({ boardId, itemId, data, position, geometry, style }) => {
     try {

--- a/src/tools/updateStickyNoteItem.ts
+++ b/src/tools/updateStickyNoteItem.ts
@@ -26,24 +26,24 @@ const updateStickyNoteItemTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board that contains the sticky note"),
     itemId: z.string().describe("Unique identifier (ID) of the sticky note that you want to update"),
     data: z.object({
-      content: z.string().optional().describe("Updated text content of the sticky note"),
-      shape: z.string().optional().describe("Updated shape of the sticky note (square, rectangle, circle, triangle, rhombus)")
-    }).optional().describe("Updated content and configuration of the sticky note"),
+      content: z.string().optional().nullish().describe("Updated text content of the sticky note"),
+      shape: z.string().optional().nullish().describe("Updated shape of the sticky note (square, rectangle, circle, triangle, rhombus)")
+    }).optional().nullish().describe("Updated content and configuration of the sticky note"),
     position: z.object({
-      x: z.number().optional().describe("Updated X coordinate of the sticky note"),
-      y: z.number().optional().describe("Updated Y coordinate of the sticky note"),
-      origin: z.string().optional().describe("Origin of the sticky note (center, top-left, etc.)"),
-      relativeTo: z.string().optional().describe("Reference point (canvas_center, etc.)")
-    }).optional().describe("Updated position of the sticky note on the board"),
+      x: z.number().optional().nullish().describe("Updated X coordinate of the sticky note"),
+      y: z.number().optional().nullish().describe("Updated Y coordinate of the sticky note"),
+      origin: z.string().optional().nullish().describe("Origin of the sticky note (center, top-left, etc.)"),
+      relativeTo: z.string().optional().nullish().describe("Reference point (canvas_center, etc.)")
+    }).optional().nullish().describe("Updated position of the sticky note on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Updated width of the sticky note"),
-      height: z.number().optional().describe("Updated height of the sticky note")
-    }).optional().describe("Updated dimensions of the sticky note"),
+      width: z.number().optional().nullish().describe("Updated width of the sticky note"),
+      height: z.number().optional().nullish().describe("Updated height of the sticky note")
+    }).optional().nullish().describe("Updated dimensions of the sticky note"),
     style: z.object({
-      fillColor: z.string().optional().describe("Updated fill color of the sticky note (use predefined values)"),
-      textAlign: z.string().optional().describe("Updated alignment of the text (left, center, right)"),
-      textColor: z.string().optional().describe("Updated color of the text on the sticky note")
-    }).optional().describe("Updated style configuration of the sticky note")
+      fillColor: z.string().optional().nullish().describe("Updated fill color of the sticky note (use predefined values)"),
+      textAlign: z.string().optional().nullish().describe("Updated alignment of the text (left, center, right)"),
+      textColor: z.string().optional().nullish().describe("Updated color of the text on the sticky note")
+    }).optional().nullish().describe("Updated style configuration of the sticky note")
   },
   fn: async ({ boardId, itemId, data, position, geometry, style }) => {
     try {

--- a/src/tools/updateTag.ts
+++ b/src/tools/updateTag.ts
@@ -11,8 +11,8 @@ const updateTagTool: ToolSchema = {
   args: {
     boardId: z.string().describe("Unique identifier (ID) of the board that contains the tag"),
     tagId: z.string().describe("Unique identifier (ID) of the tag that you want to update"),
-    title: z.string().optional().describe("Updated title of the tag"),
-    fillColor: z.string().optional().describe("Updated fill color of the tag (hex format, e.g. #000000)")
+    title: z.string().optional().nullish().describe("Updated title of the tag"),
+    fillColor: z.string().optional().nullish().describe("Updated fill color of the tag (hex format, e.g. #000000)")
   },
   fn: async ({ boardId, tagId, title, fillColor }) => {
     try {

--- a/src/tools/updateTextItem.ts
+++ b/src/tools/updateTextItem.ts
@@ -12,20 +12,20 @@ const updateTextItemTool: ToolSchema = {
     boardId: z.string().describe("Unique identifier (ID) of the board that contains the text item"),
     itemId: z.string().describe("Unique identifier (ID) of the text item that you want to update"),
     data: z.object({
-      content: z.string().optional().describe("Updated text content of the text item")
-    }).optional().describe("The updated content of the text item"),
+      content: z.string().optional().nullish().describe("Updated text content of the text item")
+    }).optional().nullish().describe("The updated content of the text item"),
     position: z.object({
-      x: z.number().optional().describe("Updated X coordinate of the text item"),
-      y: z.number().optional().describe("Updated Y coordinate of the text item")
-    }).optional().describe("Updated position of the text item on the board"),
+      x: z.number().optional().nullish().describe("Updated X coordinate of the text item"),
+      y: z.number().optional().nullish().describe("Updated Y coordinate of the text item")
+    }).optional().nullish().describe("Updated position of the text item on the board"),
     geometry: z.object({
-      width: z.number().optional().describe("Updated width of the text item")
-    }).optional().describe("Updated dimensions of the text item"),
+      width: z.number().optional().nullish().describe("Updated width of the text item")
+    }).optional().nullish().describe("Updated dimensions of the text item"),
     style: z.object({
-      color: z.string().optional().describe("Updated color of the text"),
-      fontSize: z.number().optional().describe("Updated font size of the text"),
-      textAlign: z.string().optional().describe("Updated alignment of the text (left, center, right)")
-    }).optional().describe("Updated style configuration of the text item")
+      color: z.string().optional().nullish().describe("Updated color of the text"),
+      fontSize: z.number().optional().nullish().describe("Updated font size of the text"),
+      textAlign: z.string().optional().nullish().describe("Updated alignment of the text (left, center, right)")
+    }).optional().nullish().describe("Updated style configuration of the text item")
   },
   fn: async ({ boardId, itemId, data, position, geometry, style }) => {
     try {


### PR DESCRIPTION
Currently, our optional fields are defined as Optional[Type] which defaults to None when not provided, but doesn't explicitly allow null values in JSON serialization/deserialization. This creates compatibility issues with:

OpenAI API: Expects nullable fields that can be explicitly set to null
LangChain: Relies on OpenAI-compatible schemas and expects proper null handling

This change maintains backward compatibility while enabling proper interoperability with the OpenAI ecosystem.
